### PR TITLE
Linux OOM killer stopping java process

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,13 +1,3 @@
-* Why is spring-experiments down?
-  - https://help.ubuntu.com/community/AutomaticSecurityUpdates cause OOM killer to stop java process
-  - options
-    - swap?
-      - no instance storage on t3a.nano
-      => gp2 EBS (since no IO cost)
-    - larger instance?
-    - disable upgrades
-      - risky unless automate upgrades using e.g. packer and CI
-
 * Add pip constraints file.
 
 * bash completion for packer.

--- a/TODO
+++ b/TODO
@@ -1,4 +1,12 @@
 * Why is spring-experiments down?
+  - https://help.ubuntu.com/community/AutomaticSecurityUpdates cause OOM killer to stop java process
+  - options
+    - swap?
+      - no instance storage on t3a.nano
+      => gp2 EBS (since no IO cost)
+    - larger instance?
+    - disable upgrades
+      - risky unless automate upgrades using e.g. packer and CI
 
 * Add pip constraints file.
 

--- a/resources/bin/provision
+++ b/resources/bin/provision
@@ -44,6 +44,12 @@ log "updating apt packages (to update apt sources)."
 apt_get_wrapper update
 log "updating apt packages again (with new apt sources)."
 apt_get_wrapper update
+
+log "removing unattended-upgrades"
+# It causes Linux kernel's OOM killer to stop the spring-experiments java process. Instead, CI
+# builds and deploys new images periodically.
+apt_get_wrapper purge unattended-upgrades
+
 log "installing apt packages."
 apt_get_wrapper install openjdk-17-jre-headless python3-pip
 log "installing: awscli"


### PR DESCRIPTION
From dmesg logs, can see it's from unattended-upgrades running periodically.

* EC2 instances with more memory are twice the price.
* t3a.nano doesn't have instance store that could use as swap.
* Could use gp2 EBS volume as swap at minimal cost, but it doesn't feel like good solution.
* Removing unattended-upgrades should avoid the OOM, but will need to do upgrades some other way.