### PR TITLE
python pip constraints.txt

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,8 +37,8 @@ jobs:
       run: cd terraform && terraform validate
 
     # TODO cache the package
-    - name: install graphviz (dot)
-      run: sudo apt-get install -y graphviz
+    # - name: install graphviz (dot)
+    #   run: sudo apt-get install -y graphviz
 
     # - name: terraform graph
     #   run: cd terraform && terraform graph -draw-cycles | dot -Tsvg -Gconcentrate=true > terraform.svg

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,20 @@ jobs:
       with:
         terraform_version: "1.5.6"
 
+    - uses: actions/setup-python@v6.0.0
+      with:
+        cache: 'pip'
+        cache-dependency-path: constraints.txt
+
+    - name: python version
+      run: python --version
+
+    - name: pip version
+      run: pip --version
+
+    - name: aws CLI version
+      run: aws --version
+
     - name: terraform init
       run: cd terraform && terraform init -backend=false
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ terraform apply
 ```
 
 An S3 bucket is used to store the terraform state. If this bucket doesn't exist yet, temporarily comment out the "backend" configuration in [main.tf](main.tf) while deploying, and it will be created for you (and then your temporary local state will get migrated to S3). This trick will only work if are deploying for the first time.
+
+## Upgrading python dependencies
+
+Update requirements.txt, then:
+
+```
+pip install -r requirements.txt
+pip freeze > constraints.txt
+```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An S3 bucket is used to store the terraform state. If this bucket doesn't exist 
 
 ## Upgrading python dependencies
 
-Update requirements.txt, then:
+Update requirements.txt, maybe adjust (or empty) constraints.txt, then:
 
 ```
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An S3 bucket is used to store the terraform state. If this bucket doesn't exist 
 
 ## Upgrading python dependencies
 
-Update requirements.txt, maybe adjust (or empty) constraints.txt, then:
+Update requirements.txt, then:
 
 ```
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An S3 bucket is used to store the terraform state. If this bucket doesn't exist 
 
 ## Upgrading python dependencies
 
-Update requirements.txt, then:
+Update requirements.txt, perhaps clearing or editting constraints.txt too, then:
 
 ```
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An S3 bucket is used to store the terraform state. If this bucket doesn't exist 
 
 ## Upgrading python dependencies
 
-Update requirements.txt, perhaps clearing or editting constraints.txt too, then:
+Update requirements.txt, perhaps clearing or editing constraints.txt too, then:
 
 ```
 pip install -r requirements.txt

--- a/TODO
+++ b/TODO
@@ -1,3 +1,10 @@
+* checkov terraform static analysis?
+  - finds lots of issues
+  - conflicts with awscli via botocore depencencies
+    - https://github.com/jg210/aws-experiments/pull/22#issuecomment-3426102790
+    - get them to fix this?
+    - separate venvs for the two tools?
+
 * tflint?
   - how can it be installed in a nice way?
     - docker?

--- a/TODO
+++ b/TODO
@@ -1,5 +1,7 @@
 * tflint?
   - how can it be installed in a nice way?
+    - docker?
+    - repurpose https://github.com/jg210/expo-experiments/blob/master/scripts/install_maestro?
 
 * The spring-experiments jar could be made more streamlined.
   - doesn't need to support HTTP server since only deploy with lambda

--- a/TODO
+++ b/TODO
@@ -1,3 +1,6 @@
+* tflint?
+  - how can it be installed in a nice way?
+
 * The spring-experiments jar could be made more streamlined.
   - doesn't need to support HTTP server since only deploy with lambda
   - faster startup by e.g. removing bean discovery.

--- a/TODO
+++ b/TODO
@@ -10,6 +10,14 @@
     - docker?
     - repurpose https://github.com/jg210/expo-experiments/blob/master/scripts/install_maestro?
 
+* Alternatives to requirements.txt and constraints.txt
+  - they don't remove packages that aren't listed
+  - alternatives?
+    - pip lock?
+    - pipenv?
+    - poetry?
+    - ???
+
 * The spring-experiments jar could be made more streamlined.
   - doesn't need to support HTTP server since only deploy with lambda
   - faster startup by e.g. removing bean discovery.

--- a/TODO
+++ b/TODO
@@ -2,8 +2,6 @@
   - doesn't need to support HTTP server since only deploy with lambda
   - faster startup by e.g. removing bean discovery.
 
-* Add pip constraints file.
-
 * Move commands from README.md to ~/bin/setup
 
 * EBS snapshots were building up.

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,12 @@
-awscli==1.42.55
-botocore==1.40.55
+awscli==1.31.12
+botocore==1.33.12
 colorama==0.4.4
-docutils==0.19
+docutils==0.16
 jmespath==1.0.1
 pyasn1==0.5.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
 rsa==4.7.2
-s3transfer==0.14.0
+s3transfer==0.8.2
 six==1.16.0
 urllib3==2.0.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,12 @@
-awscli==1.31.12
-botocore==1.33.12
+awscli==1.42.55
+botocore==1.40.55
 colorama==0.4.4
-docutils==0.16
+docutils==0.19
 jmespath==1.0.1
 pyasn1==0.5.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
 rsa==4.7.2
-s3transfer==0.8.2
+s3transfer==0.14.0
 six==1.16.0
 urllib3==2.0.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,12 @@
+awscli==1.31.12
+botocore==1.33.12
+colorama==0.4.4
+docutils==0.16
+jmespath==1.0.1
+pyasn1==0.5.1
+python-dateutil==2.8.2
+PyYAML==6.0.1
+rsa==4.7.2
+s3transfer==0.8.2
+six==1.16.0
+urllib3==2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+-c constraints.txt
 awscli==1.31.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-awscli==1.42.55
+awscli==1.31.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-awscli==1.31.12
+awscli==1.42.55


### PR DESCRIPTION
Add a python pip constraints.txt (approximately, a lock file). Previously, weren't controlling the version of the things now listed in constraints.txt. Likely not the best approach, so added investigating that to TODO file.

The PR also makes sure CI exercises pip install related functionality and removes needless (and slow) graphviz install.

(PR originally aimed to add checkov tool, but it's currently not installable at same time as awscli, so repurposed the PR.)